### PR TITLE
Add support for discount IDs

### DIFF
--- a/lib/stripe_mock/request_handlers/helpers/coupon_helpers.rb
+++ b/lib/stripe_mock/request_handlers/helpers/coupon_helpers.rb
@@ -7,6 +7,7 @@ module StripeMock
           attrs[:coupon]                 = coupon
           attrs[:start]                  = Time.now.to_i
           attrs[:end]                    = (DateTime.now >> coupon[:duration_in_months].to_i).to_time.to_i if coupon[:duration] == 'repeating'
+          attrs[:id]                     = new_id("di")
         end
 
         object[:discount] = Stripe::Discount.construct_from(discount_attrs)

--- a/spec/shared_stripe_examples/subscription_examples.rb
+++ b/spec/shared_stripe_examples/subscription_examples.rb
@@ -152,6 +152,7 @@ shared_examples 'Customer Subscriptions' do
       expect(subscriptions.data).to be_a(Array)
       expect(subscriptions.data.count).to eq(1)
       expect(subscriptions.data.first.discount).not_to be_nil
+      expect(subscriptions.data.first.discount.id).not_to be_nil
       expect(subscriptions.data.first.discount).to be_a(Stripe::Discount)
       expect(subscriptions.data.first.discount.coupon.id).to eq(coupon.id)
     end


### PR DESCRIPTION
Stripe API returns an ID like "di_abc123" for discount objects.