### PR TITLE
Add ability to mock customer balance transactions

### DIFF
--- a/lib/stripe_mock/data.rb
+++ b/lib/stripe_mock/data.rb
@@ -1227,6 +1227,25 @@ module StripeMock
       bts
     end
 
+    def self.mock_customer_balance_transaction(params = {})
+      currency = params[:currency] || StripeMock.default_currency
+      bt_id = params[:id] || 'cbtxn_default'
+      {
+        id: bt_id,
+        object: "customer_balance_transaction",
+        amount: -10000,
+        created: 1461880226,
+        credit_note: nil,
+        currency: currency,
+        customer: params[:customer_id],
+        description: nil,
+        ending_balance: -10000,
+        invoice: nil,
+        metadata: {},
+        type: "adjustment"
+      }.merge(params)
+    end
+
     def self.mock_balance_transaction(params = {})
       currency = params[:currency] || StripeMock.default_currency
       bt_id = params[:id] || 'test_txn_default'

--- a/lib/stripe_mock/request_handlers/balance_transactions.rb
+++ b/lib/stripe_mock/request_handlers/balance_transactions.rb
@@ -5,6 +5,7 @@ module StripeMock
       def BalanceTransactions.included(klass)
         klass.add_handler 'get /v1/balance_transactions/(.*)',  :get_balance_transaction
         klass.add_handler 'get /v1/balance_transactions',       :list_balance_transactions
+        klass.add_handler 'post /v1/customers/([^/]*)/balance_transactions',  :create_balance_transaction
       end
 
       def get_balance_transaction(route, method_url, params, headers)
@@ -21,7 +22,20 @@ module StripeMock
         Data.mock_list_object(values.map{|btxn| hide_additional_attributes(btxn)}, params)
       end
 
+      def create_balance_transaction(route, method_url, params, headers)
+        route =~ method_url
+        cus = assert_existence :customer, $1, customers[$1]
+        id = new_customer_balance_transaction($1, params)
+        balance_transactions[id]
+      end
+
       private
+
+      def new_customer_balance_transaction(customer_id, params = {})
+        id = "#{StripeMock.global_id_prefix}cbtxn_#{@balance_transaction_counter += 1}"
+        @balance_transactions[id] = Data.mock_customer_balance_transaction(params.merge(id: id, customer_id: customer_id))
+        id
+      end
 
       def hide_additional_attributes(btxn)
         # For automatic Stripe transfers, the transfer attribute on balance_transaction stores the transfer which

--- a/spec/shared_stripe_examples/balance_transaction_examples.rb
+++ b/spec/shared_stripe_examples/balance_transaction_examples.rb
@@ -60,4 +60,14 @@ shared_examples 'Balance Transaction API' do
     expect(transfer_transactions.map &:id).to include(new_txn_id, existing_txn_id)
   end
 
+  it "can create a customer credit balance" do
+    customer = Stripe::Customer.create({
+      email: 'johnny@appleseed.com',
+      description: "a description"
+    })
+    txn = Stripe::Customer.create_balance_transaction(customer.id, {amount: 500, currency: "usd"})
+    expect(txn.id).to match(/cbtxn_/)
+    expect(txn.amount).to eql(500)
+    expect(txn.customer).to eql(customer.id)
+  end
 end


### PR DESCRIPTION
Stripe provides these as a way to represent credits, see https://stripe.com/docs/billing/customer/balance